### PR TITLE
Remove deprecated -preview=dip25 switch

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -3,7 +3,7 @@ description "Safe concurrency for D"
 authors "Atila Neves"
 copyright "Copyright © 2018, Atila Neves"
 license "boost"
-dflags "-preview=dip25" "-preview=dip1000"
+dflags "-preview=dip1000"
 
 
 configuration "default" {


### PR DESCRIPTION
It's enabled by default / deprecated now, and also implied by dip1000